### PR TITLE
Provide asynchronous API for establishing a Bluetooth SPP connection

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -5,6 +5,5 @@ mod sdp;
 mod hci;
 mod socket;
 
-pub use self::socket::BtSocket;
+pub use self::socket::{BtSocket, BtSocketConnect};
 pub use self::hci::scan_devices;
-pub use self::sdp::get_rfcomm_channel;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,4 +1,4 @@
-use bluetooth::{BtAddr, BtError, BtDevice, BtProtocol};
+use bluetooth::{BtAddr, BtAsync, BtError, BtDevice, BtProtocol};
 use mio;
 use std;
 use std::io::{Read, Write};
@@ -14,7 +14,7 @@ impl BtSocket {
     pub fn new(protocol: BtProtocol) -> Result<BtSocket, BtError> {
         unimplemented!();
     }
-    pub fn connect(&mut self, addr: BtAddr) -> Result<(), BtError> {
+    pub fn connect(&mut self, addr: BtAddr) -> BtSocketConnect {
         unimplemented!();
     }
 }
@@ -41,6 +41,38 @@ impl Write for BtSocket {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> { unimplemented!() }
 
     fn flush(&mut self) -> std::io::Result<()> { unimplemented!() }
+}
+
+#[derive(Debug)]
+pub struct BtSocketConnect<'a> {
+    addr:   BtAddr,
+    socket: &'a mut BtSocket,
+}
+impl<'a> BtSocketConnect<'a> {
+    pub fn new(socket: &'a mut BtSocket, addr: BtAddr) -> Self {
+        BtSocketConnect {
+            addr:   addr.clone(),
+            socket: socket
+        }
+    }
+
+    pub fn advance(&mut self) -> Result<BtAsync, BtError> {
+        unimplemented!();
+    }
+}
+
+impl<'a> mio::Evented for BtSocketConnect<'a> {
+    fn register(&self, poll: &Poll, token: mio::Token, interest: Ready, opts: mio::PollOpt) -> std::io::Result<()> {
+        unimplemented!();
+    }
+
+    fn reregister(&self, poll: &Poll, token: mio::Token, interest: Ready, opts: mio::PollOpt) -> std::io::Result<()> {
+        unimplemented!();
+    }
+
+    fn deregister(&self, poll: &Poll) -> std::io::Result<()> {
+        unimplemented!();
+    }
 }
 
 pub fn scan_devices() -> Result<Vec<BtDevice>, BtError> {


### PR DESCRIPTION
This is a fully backwards compatible change, but it allows establishing Bluetooth connections (including the SDP step) to be done fully asynchronously. Also all of this should transparently work on Windows as well – once that is implemented.

This patch does not include device scanning because, as far as I can tell anyway, there is no asynchronous API to do so under Linux; nothing in `bluez/lib/hci.c` anyway.